### PR TITLE
Patch Onnxruntime, Sortednp, and DracoPy

### DIFF
--- a/.github/workflows/dracopy.yaml
+++ b/.github/workflows/dracopy.yaml
@@ -6,7 +6,7 @@ on:
       dracopyVersion:
         description: "DracoPy version"
         required: true
-        default: "0.5.0"
+        default: "1.4.0"
       numpyVersion:
         description: "numpy version"
         required: true
@@ -32,7 +32,7 @@ jobs:
 
       - name: Download DracoPy
         run: |
-          git clone https://gitlab.sauerburger.com/frank/sortednp.git \
+          git clone https://github.com/seung-lab/DracoPy \
             --branch "release-${DRACOPY_VERSION}" --single-branch
 
       - name: Install CMake

--- a/.github/workflows/dracopy.yaml
+++ b/.github/workflows/dracopy.yaml
@@ -22,7 +22,7 @@ jobs:
       NUMPY_VERSION: ${{ inputs.numpyVersion }}
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, macos-latest]
     defaults:
       run:
         shell: bash
@@ -34,6 +34,19 @@ jobs:
         run: |
           git clone https://github.com/seung-lab/DracoPy \
             --branch "${DRACOPY_VERSION}" --single-branch
+
+      - name: Patch Numpy version Linux
+        if: ${{ matrix.os == 'ubuntu-latest'}}
+        run: |
+          cd DracoPy
+          sed -i "s/oldest-supported-numpy/numpy>=${{ inputs.numpyVersion }}/g" pyproject.toml
+          cat pyproject.toml
+
+      - name: Patch Numpy version MacOS
+        if: ${{ matrix.os == 'macos-latest' }}
+        run: |
+          cd DracoPy
+          sed -i '' 's/oldest-supported-numpy/numpy>=${{ inputs.numpyVersion }}/g' pyproject.toml
 
       - name: Build wheels
         # uses: pypa/cibuildwheel@v2.16.5

--- a/.github/workflows/dracopy.yaml
+++ b/.github/workflows/dracopy.yaml
@@ -53,6 +53,7 @@ jobs:
 
       - uses: actions/upload-artifact@v3
         with:
+          name: wheels
           path: ./DracoPy/wheelhouse/*.whl
 
   publish:

--- a/.github/workflows/dracopy.yaml
+++ b/.github/workflows/dracopy.yaml
@@ -17,7 +17,7 @@ jobs:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     env:
-      CIBW_BUILD: "cp310-* cp311-* cp312-*"
+      CIBW_BUILD: "cp310-* cp311-*"
       DRACOPY_VERSION: ${{ inputs.dracopyVersion }}
       NUMPY_VERSION: ${{ inputs.numpyVersion }}
     strategy:

--- a/.github/workflows/dracopy.yaml
+++ b/.github/workflows/dracopy.yaml
@@ -42,7 +42,7 @@ jobs:
         # uses: pypa/cibuildwheel@v2.16.5
         # to supply options, put them in 'env', like:
         env:
-          CIBW_BEFORE_BUILD: cd DracoPy && git submodule init && git submodule update && pip install cython numpy==${{ inputs.numpyVersion }} scikit-build
+          CIBW_BEFORE_BUILD: git submodule init && git submodule update && pip install cython numpy==${{ inputs.numpyVersion }} scikit-build
           CPPFLAGS: -I/usr/local/opt/zlib/include
           LDFLAGS: -L/usr/local/opt/zlib/lib
           CIBW_SKIP: "*-musllinux*"

--- a/.github/workflows/dracopy.yaml
+++ b/.github/workflows/dracopy.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Download DracoPy
         run: |
           git clone https://github.com/seung-lab/DracoPy \
-            --branch "release-${DRACOPY_VERSION}" --single-branch
+            --branch "${DRACOPY_VERSION}" --single-branch
 
       - name: Install CMake
         uses: ssrobins/install-cmake@v1
@@ -42,7 +42,7 @@ jobs:
         uses: pypa/cibuildwheel@v2.16.5
         # to supply options, put them in 'env', like:
         env:
-          CIBW_BEFORE_BUILD: git submodule init && git submodule update && pip install cython numpy==${{ inputs.numpyVersion }} scikit-build
+          CIBW_BEFORE_BUILD: cd DracoPy && git submodule init && git submodule update && pip install cython numpy==${{ inputs.numpyVersion }} scikit-build
           CPPFLAGS: -I/usr/local/opt/zlib/include
           LDFLAGS: -L/usr/local/opt/zlib/lib
           CIBW_SKIP: "*-musllinux*"

--- a/.github/workflows/dracopy.yaml
+++ b/.github/workflows/dracopy.yaml
@@ -53,7 +53,7 @@ jobs:
 
       - uses: actions/upload-artifact@v3
         with:
-          path: ./wheelhouse/*.whl
+          path: ./DracoPy/wheelhouse/*.whl
 
   publish:
     name: Publish wheels to pypi.scm.io

--- a/.github/workflows/dracopy.yaml
+++ b/.github/workflows/dracopy.yaml
@@ -39,7 +39,7 @@ jobs:
         uses: ssrobins/install-cmake@v1
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16.5
+        # uses: pypa/cibuildwheel@v2.16.5
         # to supply options, put them in 'env', like:
         env:
           CIBW_BEFORE_BUILD: cd DracoPy && git submodule init && git submodule update && pip install cython numpy==${{ inputs.numpyVersion }} scikit-build
@@ -49,6 +49,10 @@ jobs:
           CIBW_ARCHS_MACOS: "universal2"
           CIBW_ARCHS_LINUX: "x86_64"
           CIBW_ARCHS_WINDOWS: "AMD64"
+        run: |
+          cd DracoPy
+          python -m pip install cibuildwheel==2.16.5
+          python -m cibuildwheel --output-dir wheelhouse
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/dracopy.yaml
+++ b/.github/workflows/dracopy.yaml
@@ -35,9 +35,6 @@ jobs:
           git clone https://github.com/seung-lab/DracoPy \
             --branch "${DRACOPY_VERSION}" --single-branch
 
-      - name: Install CMake
-        uses: ssrobins/install-cmake@v1
-
       - name: Build wheels
         # uses: pypa/cibuildwheel@v2.16.5
         # to supply options, put them in 'env', like:

--- a/.github/workflows/dracopy.yaml
+++ b/.github/workflows/dracopy.yaml
@@ -43,7 +43,7 @@ jobs:
           CPPFLAGS: -I/usr/local/opt/zlib/include
           LDFLAGS: -L/usr/local/opt/zlib/lib
           CIBW_SKIP: "*-musllinux*"
-          CIBW_ARCHS_MACOS: "universal2"
+          CIBW_ARCHS_MACOS: "x86_64 arm64"
           CIBW_ARCHS_LINUX: "x86_64"
           CIBW_ARCHS_WINDOWS: "AMD64"
         run: |

--- a/.github/workflows/dracopy.yaml
+++ b/.github/workflows/dracopy.yaml
@@ -22,7 +22,7 @@ jobs:
       NUMPY_VERSION: ${{ inputs.numpyVersion }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest]
     defaults:
       run:
         shell: bash

--- a/.github/workflows/dracopy.yaml
+++ b/.github/workflows/dracopy.yaml
@@ -22,7 +22,7 @@ jobs:
       NUMPY_VERSION: ${{ inputs.numpyVersion }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest]
     defaults:
       run:
         shell: bash
@@ -73,4 +73,4 @@ jobs:
           user: ${{ secrets.PYPI_SCM_USERNAME }}
           password: ${{ secrets.PYPI_SCM_PASSWORD }}
           repository-url: https://pypi.scm.io/simple/
-          skip-existing: true
+          skip-existing: false

--- a/.github/workflows/onnxruntime.yaml
+++ b/.github/workflows/onnxruntime.yaml
@@ -1,0 +1,54 @@
+name: onnxruntime
+
+on:
+  workflow_dispatch:
+    inputs:
+      onnxruntimeBranch:
+        description: "onnxruntime branch to build from"
+        required: true
+        default: "v1.19.0"
+
+jobs:
+  build_wheels:
+    name: Build onnxruntime wheel for
+    runs-on: ubuntu-latest
+    container:
+      image: quay.io/pypa/manylinux2010_x86_64
+      env:
+        PYBIN: /opt/python/cp310-cp310/bin
+    steps:
+      - name: Build wheel
+        run: |
+          $PYBIN/python -m venv /venv
+          source /venv/bin/activate
+          python3 -m pip install cmake
+          yum install -y centos-release-scl
+          yum install -y devtoolset-9
+          export PATH=/opt/rh/devtoolset-9/root/usr/bin:$PATH
+          pip install numpy==2.0 onnx packaging wheel
+          git clone --depth 1 --branch ${{ inputs.onnxruntimeBranch }} --recursive https://github.com/Microsoft/onnxruntime.git
+          cd onnxruntime/
+          ./build.sh --config Release --build_shared_lib --parallel --compile_no_warning_as_error --skip_submodule_sync --allow_running_as_root --build_wheel
+      - uses: actions/upload-artifact@v3
+        with:
+          name: wheels
+          path: /onnxruntime/build/Linux/Release/dist/*.whl
+
+  publish:
+    name: Publish wheels to pypi.scm.io
+    needs: [build_wheels]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get wheels
+        uses: actions/download-artifact@v3
+        with:
+          name: wheels
+          path: dist
+
+      - name: Publish to pypy.scm.io
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: ${{ secrets.PYPI_SCM_USERNAME }}
+          password: ${{ secrets.PYPI_SCM_PASSWORD }}
+          repository-url: https://pypi.scm.io/simple/
+          skip-existing: true

--- a/.github/workflows/onnxruntime.yaml
+++ b/.github/workflows/onnxruntime.yaml
@@ -16,17 +16,39 @@ jobs:
       image: quay.io/pypa/manylinux2010_x86_64 #We use the outdated manylinux2010 to build the wheels to ensure compatibility with older systems (e.g. CentOS 6 and glibc 2.12)
       env:
         PYBIN: /opt/python/cp310-cp310/bin
+    strategy:
+      matrix:
+        python_version: [3.10, 3.11]
     steps:
-      - name: Build wheel
+      - name: Install required yum packages
         run: |
-          $PYBIN/python -m venv /venv
-          source /venv/bin/activate
-          python3 -m pip install cmake
-          yum install -y centos-release-scl
-          yum install -y devtoolset-9
+          yum install -y wget centos-release-scl devtoolset-9
+
+      - name: Install required yum packages
+        run: |
+          wget https://github.com/conda-forge/miniforge/releases/download/24.3.0-0/Mambaforge-24.3.0-0-Linux-x86_64.sh
+          chmod +x ./Mambaforge-24.3.0-0-Linux-x86_64.sh
+          ./Mambaforge-24.3.0-0-Linux-x86_64.sh  -b
+          export PATH=/root/mambaforge/bin/:$PATH
+
+      - name: Use Mamba to create a Python environment
+        run: |
+          mamba create -n pyenv python==${{ matrix.python_version }} -y
+          mamba init
+
+      - name: Install more dependencies via pip
+        run: |
+          source ~/.bashrc
+          mamba activate pyenv
           export PATH=/opt/rh/devtoolset-9/root/usr/bin:$PATH
-          pip install numpy==2.0 onnx packaging wheel sympy
-          git clone --depth 1 --branch ${{ inputs.onnxruntimeBranch }} --recursive https://github.com/Microsoft/onnxruntime.git
+          pip install cmake numpy==2.0 onnx packaging wheel auditwheel sympy pytest
+
+      - name: Actually build the wheel
+        run: |
+          source ~/.bashrc
+          mamba activate pyenv
+          export PATH=/opt/rh/devtoolset-9/root/usr/bin:$PATH
+          git clone --depth 1 --branch v1.19.0 --recursive https://github.com/Microsoft/onnxruntime.git
           cd onnxruntime/
           ./build.sh --config Release --build_shared_lib --parallel --compile_no_warning_as_error --skip_submodule_sync --allow_running_as_root --build_wheel
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/onnxruntime.yaml
+++ b/.github/workflows/onnxruntime.yaml
@@ -34,7 +34,7 @@ jobs:
           pip install cmake numpy==2.0 onnx packaging wheel auditwheel sympy pytest
           git clone --depth 1 --branch v1.19.0 --recursive https://github.com/Microsoft/onnxruntime.git
           cd onnxruntime/
-          ./build.sh --config Release --build_shared_lib --parallel --compile_no_warning_as_error --skip_submodule_sync --allow_running_as_root --build --build_wheel
+          ./build.sh --config Release --build_shared_lib --parallel --compile_no_warning_as_error --skip_submodule_sync --allow_running_as_root --build_wheel
       - uses: actions/upload-artifact@v3
         with:
           name: wheels

--- a/.github/workflows/onnxruntime.yaml
+++ b/.github/workflows/onnxruntime.yaml
@@ -24,7 +24,7 @@ jobs:
         run: |
           yum install -y wget centos-release-scl devtoolset-9
 
-      - name: Install required yum packages
+      - name: Install Mamba
         run: |
           wget https://github.com/conda-forge/miniforge/releases/download/24.3.0-0/Mambaforge-24.3.0-0-Linux-x86_64.sh
           chmod +x ./Mambaforge-24.3.0-0-Linux-x86_64.sh

--- a/.github/workflows/onnxruntime.yaml
+++ b/.github/workflows/onnxruntime.yaml
@@ -33,21 +33,22 @@ jobs:
 
       - name: Use Mamba to create a Python environment
         run: |
+          export PATH=/root/mambaforge/bin/:/opt/rh/devtoolset-9/root/usr/bin:$PATH
           mamba create -n pyenv python==${{ matrix.python_version }} -y
           mamba init
 
       - name: Install more dependencies via pip
         run: |
+          export PATH=/root/mambaforge/bin/:/opt/rh/devtoolset-9/root/usr/bin:$PATH
           source ~/.bashrc
           mamba activate pyenv
-          export PATH=/opt/rh/devtoolset-9/root/usr/bin:$PATH
           pip install cmake numpy==2.0 onnx packaging wheel auditwheel sympy pytest
 
       - name: Actually build the wheel
         run: |
+          export PATH=/root/mambaforge/bin/:/opt/rh/devtoolset-9/root/usr/bin:$PATH
           source ~/.bashrc
           mamba activate pyenv
-          export PATH=/opt/rh/devtoolset-9/root/usr/bin:$PATH
           git clone --depth 1 --branch v1.19.0 --recursive https://github.com/Microsoft/onnxruntime.git
           cd onnxruntime/
           ./build.sh --config Release --build_shared_lib --parallel --compile_no_warning_as_error --skip_submodule_sync --allow_running_as_root --build --build_wheel

--- a/.github/workflows/onnxruntime.yaml
+++ b/.github/workflows/onnxruntime.yaml
@@ -14,8 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: quay.io/pypa/manylinux2010_x86_64 #We use the outdated manylinux2010 to build the wheels to ensure compatibility with older systems (e.g. CentOS 6 and glibc 2.12)
-      env:
-        PYBIN: /opt/python/cp310-cp310/bin
+      options: "--entrypoint /bin/bash"
     strategy:
       matrix:
         python_version: ["3.10", "3.11"]
@@ -28,7 +27,6 @@ jobs:
           chmod +x ./Mambaforge-24.3.0-0-Linux-x86_64.sh
           ./Mambaforge-24.3.0-0-Linux-x86_64.sh  -b
           export PATH=/root/mambaforge/bin/:$PATH
-          ls /root/mambaforge/bin/
           mamba create -n pyenv python==${{ matrix.python_version }} -y
           mamba init
           source ~/.bashrc

--- a/.github/workflows/onnxruntime.yaml
+++ b/.github/workflows/onnxruntime.yaml
@@ -36,7 +36,7 @@ jobs:
             pip install cmake numpy==2.0 onnx packaging wheel auditwheel sympy pytest
             git clone --depth 1 --branch ${{ inputs.onnxruntimeBranch }} --recursive https://github.com/Microsoft/onnxruntime.git
             cd onnxruntime/
-            ./build.sh --config Release --build_shared_lib --parallel --compile_no_warning_as_error --skip_submodule_sync --allow_running_as_root --build_wheel
+            ./build.sh --build --update --config Release --build_shared_lib --parallel --compile_no_warning_as_error --skip_submodule_sync --allow_running_as_root --build_wheel
             cp ./build/Linux/Release/dist/*.whl /dist
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/onnxruntime.yaml
+++ b/.github/workflows/onnxruntime.yaml
@@ -18,7 +18,7 @@ jobs:
         PYBIN: /opt/python/cp310-cp310/bin
     strategy:
       matrix:
-        python_version: [3.10, 3.11]
+        python_version: ["3.10", "3.11"]
     steps:
       - name: Build Wheel
         run: |

--- a/.github/workflows/onnxruntime.yaml
+++ b/.github/workflows/onnxruntime.yaml
@@ -28,6 +28,7 @@ jobs:
           chmod +x ./Mambaforge-24.3.0-0-Linux-x86_64.sh
           ./Mambaforge-24.3.0-0-Linux-x86_64.sh  -b
           export PATH=/root/mambaforge/bin/:$PATH
+          ls /root/mambaforge/bin/
           mamba create -n pyenv python==${{ matrix.python_version }} -y
           mamba init
           source ~/.bashrc

--- a/.github/workflows/onnxruntime.yaml
+++ b/.github/workflows/onnxruntime.yaml
@@ -12,29 +12,33 @@ jobs:
   build_wheels:
     name: Build onnxruntime wheel for
     runs-on: ubuntu-latest
-    container:
-      image: quay.io/pypa/manylinux2010_x86_64 #We use the outdated manylinux2010 to build the wheels to ensure compatibility with older systems (e.g. CentOS 6 and glibc 2.12)
-      options: "--entrypoint /bin/bash"
     strategy:
       matrix:
         python_version: ["3.10", "3.11"]
     steps:
       - name: Build Wheel
-        run: |
-          yum install -y wget centos-release-scl devtoolset-9
-          export PATH=/opt/rh/devtoolset-9/root/usr/bin:$PATH
-          wget https://github.com/conda-forge/miniforge/releases/download/24.3.0-0/Mambaforge-24.3.0-0-Linux-x86_64.sh
-          chmod +x ./Mambaforge-24.3.0-0-Linux-x86_64.sh
-          ./Mambaforge-24.3.0-0-Linux-x86_64.sh  -b
-          export PATH=/github/home/mambaforge/bin/:$PATH
-          mamba create -n pyenv python==${{ matrix.python_version }} -y
-          mamba init
-          source ~/.bashrc
-          mamba activate pyenv
-          pip install cmake numpy==2.0 onnx packaging wheel auditwheel sympy pytest
-          git clone --depth 1 --branch v1.19.0 --recursive https://github.com/Microsoft/onnxruntime.git
-          cd onnxruntime/
-          ./build.sh --config Release --build_shared_lib --parallel --compile_no_warning_as_error --skip_submodule_sync --allow_running_as_root --build_wheel
+        uses: addnab/docker-run-action@v3
+        with:
+          image: quay.io/pypa/manylinux2010_x86_64 #We use the outdated manylinux2010 to build the wheels to ensure compatibility with older systems (e.g. CentOS 6 and glibc 2.12)
+          shell: bash
+          run: |
+            yum install -y wget centos-release-scl devtoolset-9
+            export PATH=/opt/rh/devtoolset-9/root/usr/bin:$PATH
+            wget https://github.com/conda-forge/miniforge/releases/download/24.3.0-0/Mambaforge-24.3.0-0-Linux-x86_64.sh
+            chmod +x ./Mambaforge-24.3.0-0-Linux-x86_64.sh
+            ./Mambaforge-24.3.0-0-Linux-x86_64.sh  -b
+            export PATH=/github/home/mambaforge/bin/:$PATH
+            mamba create -n pyenv python==${{ matrix.python_version }} -y
+            mamba init
+            source ~/.bashrc
+            mamba activate pyenv
+            pip install cmake numpy==2.0 onnx packaging wheel auditwheel sympy pytest
+            git clone --depth 1 --branch v1.19.0 --recursive https://github.com/Microsoft/onnxruntime.git
+            cd onnxruntime/
+            ./build.sh --config Release --build_shared_lib --parallel --compile_no_warning_as_error --skip_submodule_sync --allow_running_as_root --build_wheel
+            sudo dnf -y install nodejs20
+            mv /opt/actions-runner/externals/node20/bin/node /opt/actions-runner/externals/node20/bin/node-bak
+            ln -s /usr/bin/node-20 /opt/actions-runner/externals/node20/bin/node
       - uses: actions/upload-artifact@v3
         with:
           name: wheels

--- a/.github/workflows/onnxruntime.yaml
+++ b/.github/workflows/onnxruntime.yaml
@@ -28,7 +28,7 @@ jobs:
           pip install numpy==2.0 onnx packaging wheel sympy
           git clone --depth 1 --branch ${{ inputs.onnxruntimeBranch }} --recursive https://github.com/Microsoft/onnxruntime.git
           cd onnxruntime/
-          ./build.sh --config Release --build_shared_lib --parallel --compile_no_warning_as_error --skip_submodule_sync --allow_running_as_root --build_wheel
+          ./build.sh --config Release --build_shared_lib --parallel --compile_no_warning_as_error --skip_submodule_sync --allow_running_as_root --build --build_wheel
       - uses: actions/upload-artifact@v3
         with:
           name: wheels

--- a/.github/workflows/onnxruntime.yaml
+++ b/.github/workflows/onnxruntime.yaml
@@ -34,7 +34,7 @@ jobs:
             source ~/.bashrc
             mamba activate pyenv
             pip install cmake numpy==2.0 onnx packaging wheel auditwheel sympy pytest
-            git clone --depth 1 --branch ${{ matrix.onnxruntimeBranch }} --recursive https://github.com/Microsoft/onnxruntime.git
+            git clone --depth 1 --branch ${{ inputs.onnxruntimeBranch }} --recursive https://github.com/Microsoft/onnxruntime.git
             cd onnxruntime/
             ./build.sh --config Release --build_shared_lib --parallel --compile_no_warning_as_error --skip_submodule_sync --allow_running_as_root --build_wheel
             cp ./build/Linux/Release/dist/*.whl /dist

--- a/.github/workflows/onnxruntime.yaml
+++ b/.github/workflows/onnxruntime.yaml
@@ -20,35 +20,19 @@ jobs:
       matrix:
         python_version: [3.10, 3.11]
     steps:
-      - name: Install required yum packages
+      - name: Build Wheel
         run: |
           yum install -y wget centos-release-scl devtoolset-9
-
-      - name: Install Mamba
-        run: |
+          export PATH=/opt/rh/devtoolset-9/root/usr/bin:$PATH
           wget https://github.com/conda-forge/miniforge/releases/download/24.3.0-0/Mambaforge-24.3.0-0-Linux-x86_64.sh
           chmod +x ./Mambaforge-24.3.0-0-Linux-x86_64.sh
           ./Mambaforge-24.3.0-0-Linux-x86_64.sh  -b
           export PATH=/root/mambaforge/bin/:$PATH
-
-      - name: Use Mamba to create a Python environment
-        run: |
-          export PATH=/root/mambaforge/bin/:/opt/rh/devtoolset-9/root/usr/bin:$PATH
           mamba create -n pyenv python==${{ matrix.python_version }} -y
           mamba init
-
-      - name: Install more dependencies via pip
-        run: |
-          export PATH=/root/mambaforge/bin/:/opt/rh/devtoolset-9/root/usr/bin:$PATH
           source ~/.bashrc
           mamba activate pyenv
           pip install cmake numpy==2.0 onnx packaging wheel auditwheel sympy pytest
-
-      - name: Actually build the wheel
-        run: |
-          export PATH=/root/mambaforge/bin/:/opt/rh/devtoolset-9/root/usr/bin:$PATH
-          source ~/.bashrc
-          mamba activate pyenv
           git clone --depth 1 --branch v1.19.0 --recursive https://github.com/Microsoft/onnxruntime.git
           cd onnxruntime/
           ./build.sh --config Release --build_shared_lib --parallel --compile_no_warning_as_error --skip_submodule_sync --allow_running_as_root --build --build_wheel

--- a/.github/workflows/onnxruntime.yaml
+++ b/.github/workflows/onnxruntime.yaml
@@ -20,6 +20,7 @@ jobs:
         uses: addnab/docker-run-action@v3
         with:
           image: quay.io/pypa/manylinux2010_x86_64 #We use the outdated manylinux2010 to build the wheels to ensure compatibility with older systems (e.g. CentOS 6 and glibc 2.12)
+          options: -v ${{ github.workspace }}:/dist
           shell: bash
           run: |
             yum install -y wget centos-release-scl devtoolset-9
@@ -27,22 +28,20 @@ jobs:
             wget https://github.com/conda-forge/miniforge/releases/download/24.3.0-0/Mambaforge-24.3.0-0-Linux-x86_64.sh
             chmod +x ./Mambaforge-24.3.0-0-Linux-x86_64.sh
             ./Mambaforge-24.3.0-0-Linux-x86_64.sh  -b
-            export PATH=/github/home/mambaforge/bin/:$PATH
+            export PATH=/root/mambaforge/bin/:$PATH
             mamba create -n pyenv python==${{ matrix.python_version }} -y
             mamba init
             source ~/.bashrc
             mamba activate pyenv
             pip install cmake numpy==2.0 onnx packaging wheel auditwheel sympy pytest
-            git clone --depth 1 --branch v1.19.0 --recursive https://github.com/Microsoft/onnxruntime.git
+            git clone --depth 1 --branch ${{ matrix.onnxruntimeBranch }} --recursive https://github.com/Microsoft/onnxruntime.git
             cd onnxruntime/
             ./build.sh --config Release --build_shared_lib --parallel --compile_no_warning_as_error --skip_submodule_sync --allow_running_as_root --build_wheel
-            sudo dnf -y install nodejs20
-            mv /opt/actions-runner/externals/node20/bin/node /opt/actions-runner/externals/node20/bin/node-bak
-            ln -s /usr/bin/node-20 /opt/actions-runner/externals/node20/bin/node
+            cp ./build/Linux/Release/dist/*.whl /dist
       - uses: actions/upload-artifact@v3
         with:
           name: wheels
-          path: /onnxruntime/build/Linux/Release/dist/*.whl
+          path: ${{ github.workspace }}/*.whl
 
   publish:
     name: Publish wheels to pypi.scm.io

--- a/.github/workflows/onnxruntime.yaml
+++ b/.github/workflows/onnxruntime.yaml
@@ -26,7 +26,7 @@ jobs:
           wget https://github.com/conda-forge/miniforge/releases/download/24.3.0-0/Mambaforge-24.3.0-0-Linux-x86_64.sh
           chmod +x ./Mambaforge-24.3.0-0-Linux-x86_64.sh
           ./Mambaforge-24.3.0-0-Linux-x86_64.sh  -b
-          export PATH=/root/mambaforge/bin/:$PATH
+          export PATH=/github/home/mambaforge/bin/:$PATH
           mamba create -n pyenv python==${{ matrix.python_version }} -y
           mamba init
           source ~/.bashrc

--- a/.github/workflows/onnxruntime.yaml
+++ b/.github/workflows/onnxruntime.yaml
@@ -25,7 +25,7 @@ jobs:
           yum install -y centos-release-scl
           yum install -y devtoolset-9
           export PATH=/opt/rh/devtoolset-9/root/usr/bin:$PATH
-          pip install numpy==2.0 onnx packaging wheel
+          pip install numpy==2.0 onnx packaging wheel sympy
           git clone --depth 1 --branch ${{ inputs.onnxruntimeBranch }} --recursive https://github.com/Microsoft/onnxruntime.git
           cd onnxruntime/
           ./build.sh --config Release --build_shared_lib --parallel --compile_no_warning_as_error --skip_submodule_sync --allow_running_as_root --build_wheel

--- a/.github/workflows/onnxruntime.yaml
+++ b/.github/workflows/onnxruntime.yaml
@@ -13,7 +13,7 @@ jobs:
     name: Build onnxruntime wheel for
     runs-on: ubuntu-latest
     container:
-      image: quay.io/pypa/manylinux2010_x86_64
+      image: quay.io/pypa/manylinux2010_x86_64 #We use the outdated manylinux2010 to build the wheels to ensure compatibility with older systems (e.g. CentOS 6 and glibc 2.12)
       env:
         PYBIN: /opt/python/cp310-cp310/bin
     steps:

--- a/.github/workflows/sortednp.yaml
+++ b/.github/workflows/sortednp.yaml
@@ -68,7 +68,7 @@ jobs:
       - name: Build wheels
         env:
           CIBW_SKIP: "*-musllinux*"
-          CIBW_ARCHS_MACOS: "universal2"
+          CIBW_ARCHS_MACOS: "x86_64 universal2"
           CIBW_ARCHS_LINUX: "x86_64"
           CIBW_ARCHS_WINDOWS: "AMD64"
         run: |

--- a/.github/workflows/sortednp.yaml
+++ b/.github/workflows/sortednp.yaml
@@ -14,6 +14,10 @@ on:
       cibwVersion:
         description: "cibuildwheel version"
         default: "2.12.3"
+      newVersionTag:
+        description: "The name/tag of the version published"
+        required: true
+        default: "0.5.0.1"
 
 jobs:
   build_wheels:
@@ -48,7 +52,10 @@ jobs:
         run: |
           cd sortednp
           sed -i 's/.*numpy>.*/    install_requires=["numpy>=${{ inputs.numpyVersion }}"],/g' setup.py
+          sed -i 's/.*version=.*/    version="${{ inputs.newVersionTag }}",/g' setup.py
+          sed -i 's/.*__version__=.*/__version__ = "${{ inputs.newVersionTag }}"/g' src/sortednp/__init__.py
           cat setup.py
+          cat src/sortednp/__init__.py
           sed -i "s/oldest-supported-numpy/numpy>=${{ inputs.numpyVersion }}/g" pyproject.toml
           cat pyproject.toml
 
@@ -57,6 +64,10 @@ jobs:
         run: |
           cd sortednp
           sed -i '' 's/.*numpy>.*/    install_requires=["numpy>=${{ inputs.numpyVersion }}"],/g' setup.py
+          sed -i '' 's/.*version=.*/    version="${{ inputs.newVersionTag }}",/g' setup.py
+          sed -i '' 's/.*__version__=.*/__version__ = "${{ inputs.newVersionTag }}"/g' src/sortednp/__init__.py
+          cat setup.py
+          cat src/sortednp/__init__.py
           sed -i '' 's/oldest-supported-numpy/numpy>=${{ inputs.numpyVersion }}/g' pyproject.toml
 
       - name: Install cibuildwheel

--- a/.github/workflows/sortednp.yaml
+++ b/.github/workflows/sortednp.yaml
@@ -68,7 +68,7 @@ jobs:
       - name: Build wheels
         env:
           CIBW_SKIP: "*-musllinux*"
-          CIBW_ARCHS_MACOS: "x86_64 universal2"
+          CIBW_ARCHS_MACOS: "universal2"
           CIBW_ARCHS_LINUX: "x86_64"
           CIBW_ARCHS_WINDOWS: "AMD64"
         run: |

--- a/.github/workflows/sortednp.yaml
+++ b/.github/workflows/sortednp.yaml
@@ -26,7 +26,7 @@ jobs:
       CIBW_VERSION: ${{ inputs.cibwVersion }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest]
     defaults:
       run:
         shell: bash
@@ -49,18 +49,15 @@ jobs:
           cd sortednp
           sed -i 's/.*numpy>.*/    install_requires=["numpy>=${{ inputs.numpyVersion }}"],/g' setup.py
           cat setup.py
+          sed -i "s/oldest-supported-numpy/numpy>=${{ inputs.numpyVersion }}/g" pyproject.toml
+          cat pyproject.toml
 
       - name: Patch Numpy version MacOS
         if: ${{ matrix.os == 'macos-latest' }}
         run: |
           cd sortednp
           sed -i '' 's/.*numpy>.*/    install_requires=["numpy>=${{ inputs.numpyVersion }}"],/g' setup.py
-
-      - name: Patch Numpy version Windows
-        if: ${{ matrix.os == 'windows-latest'}}
-        run: |
-          cd sortednp
-          powershell -command "(Get-Content setup.py) -replace '.*numpy>.*', '    install_requires=[\"numpy>=${{ inputs.numpyVersion }}\"],' | Set-Content setup.py"
+          sed -i '' 's/oldest-supported-numpy/numpy>=${{ inputs.numpyVersion }}/g' pyproject.toml
 
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel==${CIBW_VERSION}


### PR DESCRIPTION
THis PR includes two major changes

- Continuation of PR #3 to patch `DracoPy` and `sortednp` with numpy 2 support.
- Re-Compile `onnxruntime` for Linux with `glibc` version 2.12 to use on the out-dated Gaba environments